### PR TITLE
Browser support for background analysis

### DIFF
--- a/packages/browser-pyright/src/browserWorkersHost.ts
+++ b/packages/browser-pyright/src/browserWorkersHost.ts
@@ -1,0 +1,88 @@
+import {
+    Transferable,
+    WorkersHost,
+    MessageSourceSink,
+    MessagePort,
+    MessageChannel,
+    shallowReplace,
+} from 'pyright-internal/common/workersHost';
+
+export class BrowserWorkersHost implements WorkersHost {
+    private _parentPort: globalThis.MessagePort | undefined;
+
+    constructor(parentPort?: globalThis.MessagePort) {
+        this._parentPort = parentPort;
+    }
+
+    threadId(): string {
+        return self.name;
+    }
+
+    parentPort(): MessagePort | null {
+        return this._parentPort ? new BrowserMessagePort(this._parentPort) : null;
+    }
+
+    createWorker(initialData?: any): MessageSourceSink {
+        const channel = new globalThis.MessageChannel();
+        self.postMessage(
+            {
+                type: 'browser/newWorker',
+                initialData,
+                port: channel.port1,
+            },
+            [channel.port1]
+        );
+        channel.port1.start();
+        channel.port2.start();
+        return new BrowserMessagePort(channel.port2);
+    }
+
+    createMessageChannel(): MessageChannel {
+        const channel = new globalThis.MessageChannel();
+        return {
+            port1: new BrowserMessagePort(channel.port1),
+            port2: new BrowserMessagePort(channel.port2),
+        };
+    }
+}
+
+class BrowserMessagePort implements MessagePort {
+    constructor(private delegate: globalThis.MessagePort) {}
+    unwrap() {
+        return this.delegate;
+    }
+    postMessage(value: any, transferList?: Transferable[]): void {
+        if (transferList) {
+            this.delegate.postMessage(unwrapForSend(value), unwrapForSend(transferList));
+        } else {
+            this.delegate.postMessage(value);
+        }
+    }
+    on(type: 'message' | 'error' | 'exit', listener: (data: any) => void): void {
+        // We don't support error/exit for now.
+        if (type === 'message') {
+            this.delegate.addEventListener(type, (e: MessageEvent) => {
+                const data = e.data;
+                listener(wrapOnReceive(data));
+            });
+        }
+    }
+    start() {
+        this.delegate.start();
+    }
+    close() {
+        this.delegate.close();
+    }
+}
+
+function unwrapForSend(value: any): any {
+    return shallowReplace(value, (v: any) => {
+        return v instanceof BrowserMessagePort ? v.unwrap() : v;
+    });
+}
+
+function wrapOnReceive(value: any): any {
+    return shallowReplace(value, (v: any) => {
+        return v instanceof globalThis.MessagePort ? new BrowserMessagePort(v) : v;
+    });
+}

--- a/packages/browser-pyright/src/worker.ts
+++ b/packages/browser-pyright/src/worker.ts
@@ -1,11 +1,51 @@
 import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser';
-import { PyrightServer } from './browser-server';
 
-// @ts-ignore
-const ctx: Worker = self as any;
+import { BrowserBackgroundAnalysisRunner, PyrightServer } from './browser-server';
+import { InitializationData } from 'pyright-internal/backgroundThreadBase';
+import { initializeWorkersHost } from 'pyright-internal/common/workersHost';
+import { BrowserWorkersHost } from './browserWorkersHost';
 
-const createLanguageServer = new PyrightServer(
-    createConnection(new BrowserMessageReader(ctx), new BrowserMessageWriter(ctx))
-);
+const ctx: DedicatedWorkerGlobalScope & { app: PyrightServer | BrowserBackgroundAnalysisRunner | undefined } =
+    self as any;
 
-export default createLanguageServer;
+interface BootParams {
+    type: 'browser/boot';
+    mode: 'foreground' | 'background';
+    // Background only.
+    initialData?: InitializationData;
+    // Background only.
+    port?: MessagePort;
+}
+
+// Ideally we'd use a nested worker for the background thread but no Safari support.
+// Instead non-Worker code must facilitate the connection by creating a worker and
+// passing on a port.
+ctx.addEventListener('message', (e: MessageEvent) => {
+    if (e.data.type === 'browser/boot') {
+        const params = e.data as BootParams;
+        const { mode, port, initialData } = params;
+        try {
+            if (mode === 'foreground') {
+                initializeWorkersHost(new BrowserWorkersHost());
+                ctx.app = new PyrightServer(
+                    createConnection(new BrowserMessageReader(ctx), new BrowserMessageWriter(ctx))
+                );
+            } else if (mode === 'background') {
+                if (!initialData) {
+                    throw new Error('Missing "initialData" background boot parameter.');
+                }
+                if (!(port instanceof MessagePort)) {
+                    throw new Error(`Invalid "port" parameter: ${port}`);
+                }
+                initializeWorkersHost(new BrowserWorkersHost(port));
+                ctx.app = new BrowserBackgroundAnalysisRunner(initialData);
+                ctx.app.start();
+            } else {
+                throw new Error(`Invalid "mode" boot parameter: ${mode}`);
+            }
+        } catch (e) {
+            ctx.close();
+            throw e;
+        }
+    }
+});

--- a/packages/browser-pyright/webpack.config.js
+++ b/packages/browser-pyright/webpack.config.js
@@ -49,8 +49,9 @@ module.exports = (_, { mode }) => {
                 path: require.resolve('path-browserify'),
                 // TOML parsing which we don't use
                 stream: false,
-                // Used for isMainThread so empty is probably fine
-                worker_threads: false,
+                // fileBasedCancellationUtils (we've removed the RealFileSystem)
+                fs: false,
+                os: false,
             },
         },
         module: {

--- a/packages/pyright-internal/jest.config.js
+++ b/packages/pyright-internal/jest.config.js
@@ -23,4 +23,5 @@ module.exports = {
             },
         },
     },
+    setupFiles: ['./src/tests/setupTests.ts'],
 };

--- a/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
+++ b/packages/pyright-internal/src/analyzer/backgroundAnalysisProgram.ts
@@ -18,6 +18,7 @@ import { FileDiagnostics } from '../common/diagnosticSink';
 import { LanguageServiceExtension } from '../common/extensibility';
 import { Range } from '../common/textRange';
 import { IndexResults } from '../languageService/documentSymbolProvider';
+import { FileSet } from '../tests/harness/vfs/filesystem';
 import { AnalysisCompleteCallback, analyzeProgram } from './analysis';
 import { ImportResolver } from './importResolver';
 import { Indices, MaxAnalysisTime, Program } from './program';
@@ -94,6 +95,10 @@ export class BackgroundAnalysisProgram {
     setFileOpened(filePath: string, version: number | null, contents: string, isTracked: boolean) {
         this._backgroundAnalysis?.setFileOpened(filePath, version, [{ text: contents }], isTracked);
         this._program.setFileOpened(filePath, version, [{ text: contents }], isTracked);
+    }
+
+    initializeFileSystem(files: Record<string, string>) {
+        this._backgroundAnalysis?.initializeFileSystem(files);
     }
 
     updateOpenFileContents(

--- a/packages/pyright-internal/src/analyzer/sourceFile.ts
+++ b/packages/pyright-internal/src/analyzer/sourceFile.ts
@@ -15,7 +15,7 @@ import {
     MarkupKind,
 } from 'vscode-languageserver';
 import { TextDocument, TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
-import { isMainThread } from 'worker_threads';
+import { isMainThread } from '../common/workersHost';
 
 import * as SymbolNameUtils from '../analyzer/symbolNameUtils';
 import { OperationCanceledException } from '../common/cancellationUtils';
@@ -215,7 +215,7 @@ export class SourceFile {
         }
 
         // 'FG' or 'BG' based on current thread.
-        this._logTracker = logTracker ?? new LogTracker(console, isMainThread ? 'FG' : 'BG');
+        this._logTracker = logTracker ?? new LogTracker(console, isMainThread() ? 'FG' : 'BG');
     }
 
     getFilePath(): string {

--- a/packages/pyright-internal/src/backgroundAnalysis.ts
+++ b/packages/pyright-internal/src/backgroundAnalysis.ts
@@ -6,11 +6,14 @@
  * run analyzer from background thread
  */
 
-import { Worker } from 'worker_threads';
+import { workerData } from 'worker_threads';
 
 import { BackgroundAnalysisBase, BackgroundAnalysisRunnerBase, InitializationData } from './backgroundAnalysisBase';
 import { getCancellationFolderName } from './common/cancellationUtils';
 import { ConsoleInterface } from './common/console';
+import { FileSystem } from './common/fileSystem';
+import { createFromRealFileSystem } from './common/realFileSystem';
+import { createWorker, parentPort } from './common/workersHost';
 
 export class BackgroundAnalysis extends BackgroundAnalysisBase {
     constructor(console: ConsoleInterface) {
@@ -21,15 +24,16 @@ export class BackgroundAnalysis extends BackgroundAnalysisBase {
             cancellationFolderName: getCancellationFolderName(),
             runner: undefined,
         };
-
-        // this will load this same file in BG thread and start listener
-        const worker = new Worker(__filename, { workerData: initialData });
+        const worker = createWorker(initialData);
         this.setup(worker);
     }
 }
 
 export class BackgroundAnalysisRunner extends BackgroundAnalysisRunnerBase {
     constructor() {
-        super();
+        super(parentPort(), workerData as InitializationData);
+    }
+    protected createRealFileSystem(): FileSystem {
+        return createFromRealFileSystem(this.getConsole());
     }
 }

--- a/packages/pyright-internal/src/common/nodeWorkersHost.ts
+++ b/packages/pyright-internal/src/common/nodeWorkersHost.ts
@@ -1,0 +1,88 @@
+import {
+    parentPort,
+    MessagePort as WorkerThreadsMessagePort,
+    Worker as WorkerThreadsWorker,
+    MessageChannel as WorkerThreadsMessageChannel,
+    threadId,
+} from 'worker_threads';
+import {
+    MessageChannel,
+    MessagePort,
+    MessageSourceSink,
+    shallowReplace,
+    Transferable,
+    WorkersHost,
+} from './workersHost';
+
+export class NodeWorkersHost implements WorkersHost {
+    threadId(): string {
+        return threadId.toString();
+    }
+
+    parentPort(): MessagePort | null {
+        return parentPort ? new NodeMessagePort(parentPort) : null;
+    }
+
+    createWorker(initialData?: any): MessageSourceSink {
+        // this will load this same file in BG thread and start listener
+        const worker = new WorkerThreadsWorker(__filename, { workerData: initialData });
+        return new NodeWorker(worker);
+    }
+
+    createMessageChannel(): MessageChannel {
+        const channel = new WorkerThreadsMessageChannel();
+        return {
+            port1: new NodeMessagePort(channel.port1),
+            port2: new NodeMessagePort(channel.port2),
+        };
+    }
+}
+
+class NodeMessagePort implements MessagePort {
+    constructor(private delegate: WorkerThreadsMessagePort) {}
+    unwrap() {
+        return this.delegate;
+    }
+    postMessage(value: any, transferList?: Transferable[]): void {
+        if (transferList) {
+            this.delegate.postMessage(unwrapForSend(value), unwrapForSend(transferList));
+        } else {
+            this.delegate.postMessage(value);
+        }
+    }
+    on(type: 'message' | 'error' | 'exit', listener: (data: any) => void): void {
+        this.delegate.on(type, (data) => listener(wrapOnReceive(data)));
+    }
+    start() {
+        this.delegate.start();
+    }
+    close() {
+        this.delegate.close();
+    }
+}
+
+class NodeWorker implements MessageSourceSink {
+    constructor(private delegate: WorkerThreadsWorker) {}
+    postMessage(value: any, transferList?: Transferable[]): void {
+        if (transferList) {
+            this.delegate.postMessage(unwrapForSend(value), unwrapForSend(transferList));
+        } else {
+            this.delegate.postMessage(value);
+        }
+    }
+    on(type: 'message' | 'error' | 'exit', listener: (data: any) => void): void {
+        this.delegate.on(type, (data) => listener(wrapOnReceive(data)));
+    }
+}
+
+function unwrapForSend(value: any): any {
+    return shallowReplace(value, (v: any) => {
+        return v instanceof NodeMessagePort ? v.unwrap() : v;
+    });
+}
+
+function wrapOnReceive(value: any): any {
+    return shallowReplace(value, (v: any) => {
+        return v instanceof WorkerThreadsMessagePort ? new NodeMessagePort(v) : v;
+    });
+}

--- a/packages/pyright-internal/src/common/workersHost.ts
+++ b/packages/pyright-internal/src/common/workersHost.ts
@@ -1,0 +1,84 @@
+// This could be a more general abstraction of the host environment but for
+// now it's focussed on abstracting worker_threads vs Web Workers.
+//
+// For minimal distruption to the existing NodeJS code we use Node-type
+// events rather than MessageEvent.
+
+export type Transferable = ArrayBuffer | MessagePort;
+
+export interface MessageSourceSink {
+    // As per worker_thread, except any transferables may only be
+    // `value` itself or one level nested in an object or array value.
+    postMessage(value: any, transferList?: Transferable[]): void;
+    on(type: 'message' | 'error' | 'exit', listener: (data: any) => void): void;
+}
+
+export interface MessagePort extends MessageSourceSink {
+    start(): void;
+    close(): void;
+}
+
+export interface MessageChannel {
+    port1: MessagePort;
+    port2: MessagePort;
+}
+
+export interface WorkersHost {
+    parentPort(): MessagePort | null;
+    createWorker(initialData?: any): MessageSourceSink;
+    createMessageChannel(): MessageChannel;
+    threadId(): string;
+}
+
+let _host: undefined | WorkersHost;
+
+// This must be called by host-specific entry points.
+export function initializeWorkersHost(host: WorkersHost) {
+    _host = host;
+}
+
+function host(): WorkersHost {
+    if (!_host) {
+        throw new Error('Host must be initialized');
+    }
+    return _host;
+}
+
+export function createMessageChannel(): MessageChannel {
+    return host().createMessageChannel();
+}
+
+export function createWorker(initialData?: any): MessageSourceSink {
+    return host().createWorker(initialData);
+}
+
+export function parentPort(): MessagePort | null {
+    return host().parentPort();
+}
+
+export function threadId(): string {
+    return host().threadId();
+}
+
+export function isMainThread(): boolean {
+    return !parentPort();
+}
+
+// Utility function for implementations for wrapping/unwrapping of transferable values.
+export function shallowReplace(value: any, mapper: (v: any) => any) {
+    if (Array.isArray(value)) {
+        return value.map(mapper);
+    }
+    if (isPlainObject(value)) {
+        const shallowCopy = Object.create(null);
+        Object.entries(value).forEach(([k, v]) => {
+            shallowCopy[k] = mapper(v);
+        });
+        return shallowCopy;
+    }
+    return mapper(value);
+}
+
+function isPlainObject(v: any): boolean {
+    return Object.prototype.toString.call(v) === '[object Object]';
+}

--- a/packages/pyright-internal/src/nodeServer.ts
+++ b/packages/pyright-internal/src/nodeServer.ts
@@ -8,9 +8,12 @@
 
 import { Connection, ConnectionOptions } from 'vscode-languageserver';
 import { createConnection } from 'vscode-languageserver/node';
-import { isMainThread } from 'worker_threads';
+import { initializeWorkersHost, isMainThread } from './common/workersHost';
 
 import { getCancellationStrategyFromArgv } from './common/fileBasedCancellationUtils';
+import { NodeWorkersHost } from './common/nodeWorkersHost';
+
+initializeWorkersHost(new NodeWorkersHost());
 
 export function run(runServer: (connection: Connection) => void, runBackgroundThread: () => void) {
     if (process.env.NODE_ENV === 'production') {
@@ -18,7 +21,7 @@ export function run(runServer: (connection: Connection) => void, runBackgroundTh
         require('source-map-support').install();
     }
 
-    if (isMainThread) {
+    if (isMainThread()) {
         runServer(createConnection(getConnectionOptions()));
     } else {
         runBackgroundThread();

--- a/packages/pyright-internal/src/tests/setupTests.ts
+++ b/packages/pyright-internal/src/tests/setupTests.ts
@@ -1,0 +1,4 @@
+import { initializeWorkersHost } from '../common/workersHost';
+import { NodeWorkersHost } from '../common/nodeWorkersHost';
+
+initializeWorkersHost(new NodeWorkersHost());


### PR DESCRIPTION
Background analysis now runs in a separate worker. 

A bit of extra faff because [Safari doesn't support nested workers](https://bugs.webkit.org/show_bug.cgi?id=22723), so we need API to allow a worker to start a sibling worker via the main browser thread.

The files absolutely have to exist on the file system for them to be importable so I've added create/delete notifications for the file system. I was half tempted to relax that requirement so having the files "open" was enough but it's a bit awkward to communicate the state.

I've not given cancellation any thought. In Node it uses the file system as a side channel. Maybe IndexDB? I'll look at that in future.