### PR TITLE
Add warning diagnostic for V2 API use

### DIFF
--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4966,7 +4966,7 @@ export class Checker extends ParseTreeWalker {
         }
         if (primaryDeclaration && primaryDeclaration.node !== node) {
             switch (primaryDeclaration.type) {
-                case DeclarationType.Class /* fallthrough */:
+                case DeclarationType.Class:
                     return this._reportMicrobitVersionApiUnsupportedCheck(
                         node,
                         primaryDeclaration.moduleName,

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4973,7 +4973,6 @@ export class Checker extends ParseTreeWalker {
                         primaryDeclaration.moduleName,
                         primaryDeclaration.node.name.value
                     );
-                    break;
                 case DeclarationType.Variable:
                     if (primaryDeclaration.node.nodeType === ParseNodeType.Name) {
                         return this._reportMicrobitVersionApiUnsupportedCheck(

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -4944,8 +4944,8 @@ export class Checker extends ParseTreeWalker {
         });
     }
 
-    private _reportMicrobitV2Name(node: NameNode) {
-        if (this._fileInfo.isStubFile) {
+    private _reportMicrobitV2Name(node?: NameNode) {
+        if (!node || this._fileInfo.isStubFile) {
             return;
         }
         const type = this._evaluator.getType(node);

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1210,7 +1210,7 @@ export class Checker extends ParseTreeWalker {
     override visitName(node: NameNode) {
         // Determine if we should log information about private usage.
         this._conditionallyReportPrivateUsage(node);
-        this._reportMicrobitV2Name(node);
+        this._reportMicrobitVersionApiUnsupported(node);
 
         // Determine if the name is possibly unbound.
         if (!this._isUnboundCheckSuppressed) {
@@ -1239,7 +1239,7 @@ export class Checker extends ParseTreeWalker {
     override visitMemberAccess(node: MemberAccessNode) {
         this._evaluator.getType(node);
         this._conditionallyReportPrivateUsage(node.memberName);
-        this._reportMicrobitV2Name(node.memberName);
+        this._reportMicrobitVersionApiUnsupported(node.memberName);
 
         // Walk the leftExpression but not the memberName.
         this.walk(node.leftExpression);
@@ -1249,7 +1249,7 @@ export class Checker extends ParseTreeWalker {
 
     override visitImportAs(node: ImportAsNode): boolean {
         this._evaluator.evaluateTypesForStatement(node);
-        this._reportMicrobitV2Name(node.module.nameParts[0]);
+        this._reportMicrobitVersionApiUnsupported(node.module.nameParts[0]);
 
         return false;
     }
@@ -1258,7 +1258,7 @@ export class Checker extends ParseTreeWalker {
         if (!node.isWildcardImport) {
             node.imports.forEach((importAs) => {
                 this._evaluator.evaluateTypesForStatement(importAs);
-                this._reportMicrobitV2Name(importAs.alias ?? importAs.name);
+                this._reportMicrobitVersionApiUnsupported(importAs.alias ?? importAs.name);
             });
         } else {
             const importInfo = AnalyzerNodeInfo.getImportInfo(node.module);
@@ -1277,7 +1277,7 @@ export class Checker extends ParseTreeWalker {
                 );
             }
         }
-        this._reportMicrobitV2Name(node.module.nameParts[0]);
+        this._reportMicrobitVersionApiUnsupported(node.module.nameParts[0]);
 
         return false;
     }
@@ -4944,8 +4944,7 @@ export class Checker extends ParseTreeWalker {
         });
     }
 
-    // This message omits the class name which is confusing
-    private _reportMicrobitV2Name(node?: NameNode) {
+    private _reportMicrobitVersionApiUnsupported(node?: NameNode) {
         if (!node || this._fileInfo.isStubFile) {
             return;
         }

--- a/packages/pyright-internal/src/analyzer/checker.ts
+++ b/packages/pyright-internal/src/analyzer/checker.ts
@@ -1258,8 +1258,7 @@ export class Checker extends ParseTreeWalker {
         if (!node.isWildcardImport) {
             node.imports.forEach((importAs) => {
                 this._evaluator.evaluateTypesForStatement(importAs);
-
-                this._reportMicrobitV2Name(importAs.name);
+                this._reportMicrobitV2Name(importAs.alias ?? importAs.name);
             });
         } else {
             const importInfo = AnalyzerNodeInfo.getImportInfo(node.module);
@@ -4946,6 +4945,13 @@ export class Checker extends ParseTreeWalker {
     }
 
     private _reportMicrobitV2Name(node: NameNode) {
+        if (this._fileInfo.isStubFile) {
+            return;
+        }
+        const type = this._evaluator.getType(node);
+        if (!type || type.category === TypeCategory.Unknown) {
+            return;
+        }
         const declarations = this._evaluator.getDeclarationsForNameNode(node);
         let primaryDeclaration =
             declarations && declarations.length > 0 ? declarations[declarations.length - 1] : undefined;
@@ -4980,8 +4986,7 @@ export class Checker extends ParseTreeWalker {
             }
         }
 
-        const type = this._evaluator.getType(node);
-        if (type && isModule(type)) {
+        if (isModule(type)) {
             return this._reportMicrobitVersionApiUnsupportedCheck(node, type.moduleName);
         }
     }

--- a/packages/pyright-internal/src/common/configOptions.ts
+++ b/packages/pyright-internal/src/common/configOptions.ts
@@ -285,6 +285,9 @@ export interface DiagnosticRuleSet {
     // Report cases where the a "match" statement is not exhaustive in
     // covering all possible cases.
     reportMatchNotExhaustive: DiagnosticLevel;
+
+    // Report micro:bit V2 API use.
+    reportMicrobitVersionApiUnsupported: DiagnosticLevel;
 }
 
 export function cloneDiagnosticRuleSet(diagSettings: DiagnosticRuleSet): DiagnosticRuleSet {
@@ -374,6 +377,7 @@ export function getDiagLevelDiagnosticRules() {
         DiagnosticRule.reportUnusedCoroutine,
         DiagnosticRule.reportUnnecessaryTypeIgnoreComment,
         DiagnosticRule.reportMatchNotExhaustive,
+        DiagnosticRule.reportMicrobitVersionApiUnsupported,
     ];
 }
 
@@ -453,6 +457,7 @@ export function getOffDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedCoroutine: 'none',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'none',
+        reportMicrobitVersionApiUnsupported: 'none',
     };
 
     return diagSettings;
@@ -528,6 +533,7 @@ export function getBasicDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedCoroutine: 'error',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'none',
+        reportMicrobitVersionApiUnsupported: 'warning',
     };
 
     return diagSettings;
@@ -603,6 +609,7 @@ export function getStrictDiagnosticRuleSet(): DiagnosticRuleSet {
         reportUnusedCoroutine: 'error',
         reportUnnecessaryTypeIgnoreComment: 'none',
         reportMatchNotExhaustive: 'error',
+        reportMicrobitVersionApiUnsupported: 'warning',
     };
 
     return diagSettings;

--- a/packages/pyright-internal/src/common/diagnosticRules.ts
+++ b/packages/pyright-internal/src/common/diagnosticRules.ts
@@ -75,4 +75,6 @@ export enum DiagnosticRule {
     reportUnusedCoroutine = 'reportUnusedCoroutine',
     reportUnnecessaryTypeIgnoreComment = 'reportUnnecessaryTypeIgnoreComment',
     reportMatchNotExhaustive = 'reportMatchNotExhaustive',
+
+    reportMicrobitVersionApiUnsupported = 'reportMicrobitVersionApiUnsupported',
 }

--- a/packages/pyright-internal/src/localization/localize.ts
+++ b/packages/pyright-internal/src/localization/localize.ts
@@ -521,6 +521,10 @@ export namespace Localizer {
             );
         export const methodReturnsNonObject = () =>
             new ParameterizedString<{ name: string }>(getRawString('Diagnostic.methodReturnsNonObject'));
+        export const microbitVersionApiUnsupported = () =>
+            new ParameterizedString<{ name: string; device: string }>(
+                getRawString('Diagnostic.microbitVersionApiUnsupported')
+            );
         export const missingProtocolMembers = () => getRawString('Diagnostic.missingProtocolMembers');
         export const missingSuperCall = () =>
             new ParameterizedString<{ methodName: string }>(getRawString('Diagnostic.missingSuperCall'));

--- a/packages/pyright-internal/src/localization/package.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/package.nls.en-us.json
@@ -235,6 +235,7 @@
         "moduleAsType": "Module cannot be used as a type",
         "moduleNotCallable": "Module is not callable",
         "moduleUnknownMember": "\"{name}\" is not a known member of module \"{module}\"",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "namedExceptAfterCatchAll": "A named except clause cannot appear after catch-all except clause",
         "namedParamAfterParamSpecArgs": "Keyword parameter \"{name}\" cannot appear in signature after ParamSpec args parameter",
         "namedTupleEmptyName": "Names within a named tuple cannot be empty",

--- a/packages/pyright-internal/src/localization/simplified.nls.ca.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.ca.json
@@ -58,6 +58,7 @@
         "memberSet": "No es pot assignar el membre \"{name}\" per al tipus \"{type}\"",
         "moduleNotCallable": "El mòdul no es pot cridar",
         "moduleUnknownMember": "\"{name}\" no és un membre conegut del mòdul \"{module}\"",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "L'argument no predeterminat va després de l'argument predeterminat",
         "noOverload": "Els arguments no coincideixen amb els tipus de paràmetres",
         "objectNotCallable": "L'objecte no es pot cridar",

--- a/packages/pyright-internal/src/localization/simplified.nls.de.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.de.json
@@ -58,6 +58,7 @@
         "memberSet": "Kann Mitglied \"{name}\" nicht für Typ \"{type}\" zuweisen",
         "moduleNotCallable": "Modul ist nicht abrufbar",
         "moduleUnknownMember": "„{name}“ ist kein bekanntes Mitglied des Moduls „{module}“",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "Nicht-Standard Argument folgt Standardargument",
         "noOverload": "Argumente stimmen nicht mit Parametertypen überein",
         "objectNotCallable": "Objekt ist nicht abrufbar",

--- a/packages/pyright-internal/src/localization/simplified.nls.en-us.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.en-us.json
@@ -58,6 +58,7 @@
         "memberSet": "Cannot assign member \"{name}\" for type \"{type}\"",
         "moduleNotCallable": "Module is not callable",
         "moduleUnknownMember": "\"{name}\" is not a known member of module \"{module}\"",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "Non-default argument follows default argument",
         "noOverload": "Arguments do not match parameter types",
         "objectNotCallable": "Object is not callable",

--- a/packages/pyright-internal/src/localization/simplified.nls.es-es.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.es-es.json
@@ -58,6 +58,7 @@
         "memberSet": "No se puede asignar el miembro \"{name}\" para el tipo \"{type}\"",
         "moduleNotCallable": "No se puede llamar al módulo",
         "moduleUnknownMember": "\"{name}\" no es un miembro conocido del módulo \"{module}\"",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "Argumento no por defecto después de argumento por defecto",
         "noOverload": "Los tipos de los argumentos no coinciden con los tipos de los parámetros",
         "objectNotCallable": "No se puede llamar al objeto",

--- a/packages/pyright-internal/src/localization/simplified.nls.fr.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.fr.json
@@ -58,6 +58,7 @@
         "memberSet": "Impossible d'affecter le membre \"{name}\" pour le type \"{type}\"",
         "moduleNotCallable": "Le module n'est pas appelable",
         "moduleUnknownMember": "\"{name}\" n'est pas un membre connu du module \"{module}\"",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "Argument sans valeur par défaut suit un argument ayant une valeur par défaut",
         "noOverload": "Les arguments ne correspondent pas aux types des paramètres",
         "objectNotCallable": "L'objet n'est pas appelable",

--- a/packages/pyright-internal/src/localization/simplified.nls.ja.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.ja.json
@@ -58,6 +58,7 @@
         "memberSet": "型「{type}」の メンバー「{name}」 を割り当てできません",
         "moduleNotCallable": "モジュールは呼び出しできません",
         "moduleUnknownMember": "「{name}」はモジュール「{module}」の既知のメンバではありません",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "デフォルトでない引数はデフォルト引数の後に続きます",
         "noOverload": "引数がパラメータ型と一致しません",
         "objectNotCallable": "オブジェクトは呼び出しできません",

--- a/packages/pyright-internal/src/localization/simplified.nls.ko.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.ko.json
@@ -58,6 +58,7 @@
         "memberSet": "\"{type}\" 유형으로 \"{name}\" 멤버를 할당할 수 없음",
         "moduleNotCallable": "모듈을 호출할 수 없음",
         "moduleUnknownMember": "\"{name}\"(이)가 \"{module}\"의 기존 멤버가 아님",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "기본값 인자 뒤에 기본값이 아닌 인자가 입력됨",
         "noOverload": "인자가 매개변수 유형과 일치하지 않음",
         "objectNotCallable": "개체를 호출할 수 없음",

--- a/packages/pyright-internal/src/localization/simplified.nls.lol.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.lol.json
@@ -58,6 +58,7 @@
         "memberSet": "crwdns331292:0{name}crwdnd331292:0{type}crwdne331292:0",
         "moduleNotCallable": "crwdns331294:0crwdne331294:0",
         "moduleUnknownMember": "crwdns331296:0{name}crwdnd331296:0{module}crwdne331296:0",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "crwdns331298:0crwdne331298:0",
         "noOverload": "crwdns331300:0crwdne331300:0",
         "objectNotCallable": "crwdns331302:0crwdne331302:0",

--- a/packages/pyright-internal/src/localization/simplified.nls.nl.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.nl.json
@@ -58,6 +58,7 @@
         "memberSet": "Kan lid \"{name}\" niet toewijzen voor type \"{type}\"",
         "moduleNotCallable": "Module kan niet aangeroepen worden",
         "moduleUnknownMember": "\"{name}\" is geen bekend lid van module \"{module}\"",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "Niet standaard argument volgt het standaard argument",
         "noOverload": "Argumenten komen niet overeen met parametertypes",
         "objectNotCallable": "Object kan niet aangeroepen worden",

--- a/packages/pyright-internal/src/localization/simplified.nls.zh-cn.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.zh-cn.json
@@ -58,6 +58,7 @@
         "memberSet": "无法为类型 “{type}” 分配成员 “{name}”",
         "moduleNotCallable": "模块不可调用",
         "moduleUnknownMember": "\"{name}\" 不是模块 \"{module}\" 的已知成员",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "默认参数之后为非默认参数",
         "noOverload": "参数与参数类型不匹配",
         "objectNotCallable": "对象不可调用",

--- a/packages/pyright-internal/src/localization/simplified.nls.zh-tw.json
+++ b/packages/pyright-internal/src/localization/simplified.nls.zh-tw.json
@@ -58,6 +58,7 @@
         "memberSet": "無法指派類型 \"{type}\" 的成員 \"{name}\"",
         "moduleNotCallable": "模組不可呼叫",
         "moduleUnknownMember": "\"{name}\" 不是模組 \"{module}\" 的已知成員",
+        "microbitVersionApiUnsupported": "\"{name}\" is not supported on a {device}",
         "nonDefaultAfterDefault": "非預設引數接在預設引數後面",
         "noOverload": "引數與參數類型不相符",
         "objectNotCallable": "物件不可呼叫",

--- a/packages/pyright-internal/src/tests/fourslash/microbit.fourslash.ts
+++ b/packages/pyright-internal/src/tests/fourslash/microbit.fourslash.ts
@@ -1,0 +1,61 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: microbit/__init__.py
+// @library true
+//// from . import audio as audio
+//// def run_every():
+////     pass
+////
+//// class Sound:
+////     GIGGLE = 1
+
+// @filename: microbit/audio.py
+// @library true
+//// class SoundEffect:
+////     pass
+
+// @filename: log.py
+// @library true
+//// def add():
+////     pass
+
+// @filename: neopixel.py
+// @library true
+//// class NeoPixel:
+////     def fill(self):
+////         pass
+
+// @filename: test0.py
+//// from microbit import *
+//// [|/*wildcardUse*/run_every|]()
+
+// @filename: test1.py
+//// from microbit import [|/*importFrom*/run_every|]
+//// [|/*functionCall*/run_every|]()
+
+// @filename: test2.py
+//// import [|/*import*/log|]
+//// [|/*moduleReference*/log|].[|/*functionCall2*/add|]()
+
+// @filename: test3.py
+//// import neopixel
+//// np = neopixel.NeoPixel()
+//// np.[|/*methodCall*/fill|]()
+
+// @filename: test4.py
+//// from microbit import *
+//// [|/*classRef*/Sound|].GIGGLE
+//// audio.[|/*constructor*/SoundEffect|]()
+
+// @ts-ignore
+await helper.verifyDiagnostics({
+    wildcardUse: { category: 'warning', message: `"run_every" is not supported on a micro:bit V1` },
+    importFrom: { category: 'warning', message: `"run_every" is not supported on a micro:bit V1` },
+    functionCall: { category: 'warning', message: `"run_every" is not supported on a micro:bit V1` },
+    import: { category: 'warning', message: `"log" is not supported on a micro:bit V1` },
+    moduleReference: { category: 'warning', message: `"log" is not supported on a micro:bit V1` },
+    functionCall2: { category: 'warning', message: `"log.add" is not supported on a micro:bit V1` },
+    methodCall: { category: 'warning', message: `"NeoPixel.fill" is not supported on a micro:bit V1` },
+    classRef: { category: 'warning', message: `"Sound" is not supported on a micro:bit V1` },
+    constructor: { category: 'warning', message: `"audio.SoundEffect" is not supported on a micro:bit V1` },
+});

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -535,6 +535,11 @@ export class TestState {
 
         // organize things per file
         const resultPerFile = this._getDiagnosticsPerFile();
+        Array.from(resultPerFile.keys()).forEach((k) => {
+            resultPerFile.get(k)?.warnings.forEach((e) => {
+                console.log(k, e);
+            });
+        });
         const rangePerFile = this.createMultiMap<Range>(this.getRanges(), (r) => r.fileName);
 
         if (!hasDiagnostics(resultPerFile) && rangePerFile.size === 0) {

--- a/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
+++ b/packages/pyright-internal/src/tests/harness/fourslash/testState.ts
@@ -535,11 +535,6 @@ export class TestState {
 
         // organize things per file
         const resultPerFile = this._getDiagnosticsPerFile();
-        Array.from(resultPerFile.keys()).forEach((k) => {
-            resultPerFile.get(k)?.warnings.forEach((e) => {
-                console.log(k, e);
-            });
-        });
         const rangePerFile = this.createMultiMap<Range>(this.getRanges(), (r) => r.fileName);
 
         if (!hasDiagnostics(resultPerFile) && rangePerFile.size === 0) {

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -754,7 +754,7 @@
                         "reportMicrobitVersionApiUnsupported": {
                             "type": "string",
                             "description": "Controls reporting of micro:bit API use that isn't available on all devices",
-                            "default": "none",
+                            "default": "warning",
                             "enum": [
                                 "none",
                                 "information",

--- a/packages/vscode-pyright/package.json
+++ b/packages/vscode-pyright/package.json
@@ -750,6 +750,17 @@
                                 "warning",
                                 "error"
                             ]
+                        },
+                        "reportMicrobitVersionApiUnsupported": {
+                            "type": "string",
+                            "description": "Controls reporting of micro:bit API use that isn't available on all devices",
+                            "default": "none",
+                            "enum": [
+                                "none",
+                                "information",
+                                "warning",
+                                "error"
+                            ]
                         }
                     }
                 },

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -483,7 +483,7 @@
       "$id": "#/properties/reportMicrobitVersionApiUnsupported",
       "$ref": "#/definitions/diagnostic",
       "title": "Controls reporting of micro:bit API use that isn't available on all devices",
-      "default": "none"
+      "default": "warning"
     },
     "extraPaths": {
       "$id": "#/properties/extraPaths",

--- a/packages/vscode-pyright/schemas/pyrightconfig.schema.json
+++ b/packages/vscode-pyright/schemas/pyrightconfig.schema.json
@@ -479,6 +479,12 @@
       "title": "Controls reporting of 'match' statements that do not exhaustively match all possible values",
       "default": "none"
     },
+    "reportMicrobitVersionApiUnsupported": {
+      "$id": "#/properties/reportMicrobitVersionApiUnsupported",
+      "$ref": "#/definitions/diagnostic",
+      "title": "Controls reporting of micro:bit API use that isn't available on all devices",
+      "default": "none"
+    },
     "extraPaths": {
       "$id": "#/properties/extraPaths",
       "type": "array",


### PR DESCRIPTION
Alternative to https://github.com/microbit-foundation/pyright/pull/33

I've tried to pull the logic into checker.ts which feels more suitable for a high-level check.

Test data (I think the key parts of this are now in the automated tests):

```python
# Imports go at the top
from microbit import *
from microbit import run_every
import log
import neopixel
from power import deep_sleep
import power

power.off()

deep_sleep(10)

log.add({
  'temperature': temperature(),
  'sound': microphone.sound_level(),
  'light': display.read_light_level()
})

pin_logo.get_mode()
pin_speaker
Sound.GIGGLE

audio.SoundEffect()

pin0.CAPACITIVE

np = neopixel.NeoPixel(pin12, 8)
np.fill((0, 0, 233))
np.write()
```